### PR TITLE
Fixed issue with selected token height. Once name is longer then sele…

### DIFF
--- a/packages/exmg-paper-combobox/exmg-paper-combobox.ts
+++ b/packages/exmg-paper-combobox/exmg-paper-combobox.ts
@@ -628,6 +628,7 @@ export class PaperComboboxElement extends LitElement {
           min-height: 24px;
           position: relative;
           width: 100%;
+          white-space: nowrap;
         }
         .tokens paper-button {
           margin: 0;


### PR DESCRIPTION
Fixed issue with selected token height. Once name is longer then selected
token value remain inline but its height became bigger which looks bad.

It is only fixing issue with not allowing to grow height of token.
After merging it is good to update exmg-charts to newest version.

It should just cut off selected value text when too long (ellipsis) but now token content just overflow-x. If we disallow overflow then button icon disappear.  Seems that markup and styling should be evaluated and fixed.