### PR TITLE
LLS 816

### DIFF
--- a/packages/exmg-paper-token-input/demo/index.html
+++ b/packages/exmg-paper-token-input/demo/index.html
@@ -22,6 +22,21 @@
   </head>
   <body>
     <div class="vertical-section-container centered">
+      <h3>Multiline example</h3>
+      <demo-snippet style="width: 300px;">
+        <template>
+          <exmg-paper-token-input label="Select Users" allow-multiline="" selected-values="[1, 2, 3, 4, 5, 6]">
+            <paper-item>Rubin</paper-item>
+            <paper-item>Gennie</paper-item>
+            <paper-item>Ronna</paper-item>
+            <paper-item>Ronnie</paper-item>
+            <paper-item>SERGE</paper-item>
+            <paper-item>YENN</paper-item>
+            <paper-item>MICHEL</paper-item>
+            <paper-item>PASCAL</paper-item>
+          </exmg-paper-token-input>
+        </template>
+      </demo-snippet>
       <h3>Basic exmg-paper-token-input demo</h3>
       <demo-snippet>
         <template>

--- a/packages/exmg-paper-token-input/exmg-paper-token-input.ts
+++ b/packages/exmg-paper-token-input/exmg-paper-token-input.ts
@@ -116,6 +116,12 @@ export class PaperTokenInputElement extends LitElement {
   public alwaysFloatLabel: boolean = false;
 
   /**
+   * Sets if the input must wrap all selected items into a scrollable line or display it on multiple lines.
+   */
+  @property({type: Boolean, attribute: 'allow-multiline'})
+  public allowMultiLine: boolean = false;
+
+  /**
    * Maximum number of tokens allowed in value
    */
   @property({type: Number, attribute: 'max-tokens'})
@@ -332,10 +338,7 @@ export class PaperTokenInputElement extends LitElement {
     const items = this.querySelectorAll('paper-item');
 
     for (let i = 0; i < items.length; i = i + 1) {
-      if (
-        this.inputValue.length > 0 &&
-        (items[i].textContent || '').toLowerCase().indexOf(this.inputValue.toLowerCase()) === -1
-      ) {
+      if (this.inputValue.length > 0 && (items[i].textContent || '').toLowerCase().indexOf(this.inputValue.toLowerCase()) === -1) {
         items[i].setAttribute('hidden', '');
       } else {
         items[i].removeAttribute('hidden');
@@ -389,9 +392,7 @@ export class PaperTokenInputElement extends LitElement {
 
       return {
         id: this.getPaperItemValue(item),
-        text:
-          (this.selectedItemSelector ? item.querySelector(this.selectedItemSelector)!.textContent : item.textContent) ||
-          '',
+        text: (this.selectedItemSelector ? item.querySelector(this.selectedItemSelector)!.textContent : item.textContent) || '',
         sortWeight: this.selectedValues.indexOf(id),
       };
     })
@@ -443,6 +444,7 @@ export class PaperTokenInputElement extends LitElement {
   }
 
   protected render() {
+    console.log('this.', this.allowMultiLine);
     return html`
       <!--suppress CssUnresolvedCustomPropertySet, CssUnresolvedCustomProperty -->
       <style>
@@ -461,7 +463,7 @@ export class PaperTokenInputElement extends LitElement {
           min-height: 24px;
           position: relative;
           width: 100%;
-          white-space: nowrap;
+          white-space: ${this.allowMultiLine ? 'unset' : 'nowrap'};
         }
 
         .tokens paper-button {

--- a/packages/exmg-paper-token-input/exmg-paper-token-input.ts
+++ b/packages/exmg-paper-token-input/exmg-paper-token-input.ts
@@ -338,7 +338,10 @@ export class PaperTokenInputElement extends LitElement {
     const items = this.querySelectorAll('paper-item');
 
     for (let i = 0; i < items.length; i = i + 1) {
-      if (this.inputValue.length > 0 && (items[i].textContent || '').toLowerCase().indexOf(this.inputValue.toLowerCase()) === -1) {
+      if (
+        this.inputValue.length > 0 &&
+        (items[i].textContent || '').toLowerCase().indexOf(this.inputValue.toLowerCase()) === -1
+      ) {
         items[i].setAttribute('hidden', '');
       } else {
         items[i].removeAttribute('hidden');
@@ -392,7 +395,9 @@ export class PaperTokenInputElement extends LitElement {
 
       return {
         id: this.getPaperItemValue(item),
-        text: (this.selectedItemSelector ? item.querySelector(this.selectedItemSelector)!.textContent : item.textContent) || '',
+        text:
+          (this.selectedItemSelector ? item.querySelector(this.selectedItemSelector)!.textContent : item.textContent) ||
+          '',
         sortWeight: this.selectedValues.indexOf(id),
       };
     })
@@ -444,7 +449,6 @@ export class PaperTokenInputElement extends LitElement {
   }
 
   protected render() {
-    console.log('this.', this.allowMultiLine);
     return html`
       <!--suppress CssUnresolvedCustomPropertySet, CssUnresolvedCustomProperty -->
       <style>

--- a/packages/exmg-paper-token-input/package-lock.json
+++ b/packages/exmg-paper-token-input/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@exmg/exmg-paper-token-input",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/exmg-paper-token-input/package.json
+++ b/packages/exmg-paper-token-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exmg/exmg-paper-token-input",
   "flat": true,
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Paper style token input element",
   "contributors": [
     "Ex Machina"

--- a/packages/exmg-paper-token-input/test/exmg-paper-token-input.spec.ts
+++ b/packages/exmg-paper-token-input/test/exmg-paper-token-input.spec.ts
@@ -69,17 +69,9 @@ suite('<exmg-paper-token-input>', function() {
       assert.isNotNull(listBox.selectedValues, 'Should be an array');
       assert.equal(listBox.selectedValues![0], expectedSelectedItemValue);
       assert.lengthOf(listBox.selectedItems!, 1);
-      assert.equal(
-        listBox.selectedItems![0].innerText,
-        expectedSelectedItemText,
-        'Selected item should match with item text',
-      );
+      assert.equal(listBox.selectedItems![0].innerText, expectedSelectedItemText, 'Selected item should match with item text');
       const paperButton = elementShadowRoot.querySelector('paper-button')!;
-      assert.equal(
-        paperButton.innerText,
-        expectedSelectedItemText.toUpperCase(),
-        'Button token should match with item text',
-      );
+      assert.equal(paperButton.innerText, expectedSelectedItemText.toUpperCase(), 'Button token should match with item text');
     });
 
     test('element should trigger event exmg-token-input-select', async () => {

--- a/packages/exmg-paper-token-input/test/utils.ts
+++ b/packages/exmg-paper-token-input/test/utils.ts
@@ -2,9 +2,7 @@ import {LitElement} from 'lit-element';
 
 export const promisifyFlush = (flush: Function) => () => new Promise(resolve => flush(resolve));
 
-const onEvent: (eventName: string) => (element: LitElement) => Promise<any> = (eventName: string) => (
-  element: LitElement,
-) =>
+const onEvent: (eventName: string) => (element: LitElement) => Promise<any> = (eventName: string) => (element: LitElement) =>
   new Promise(resolve => {
     element.addEventListener(eventName, (event: Event) => resolve(event));
   });


### PR DESCRIPTION
Adds a property to `exmg-token-input` : `allow-multiline` 

Ifset to true the tokens container will no long wrap content on one line but will stackup for a more readable input.